### PR TITLE
Fix invalid regex error during 'npm run build'

### DIFF
--- a/src/vscode/src/format/formatExtension.ts
+++ b/src/vscode/src/format/formatExtension.ts
@@ -151,11 +151,11 @@ function configureLanguage(context: vscode.ExtensionContext): void {
                     action: { indentAction: vscode.IndentAction.None, appendText: ' * ' }
                 },
                 {
-                    beforeText: /^({2})* \*( ([^*]|\*(?!\/))*)?$/,
+                    beforeText: /^( {2})* \*( ([^*]|\*(?!\/))*)?$/,
                     action: { indentAction: vscode.IndentAction.None, appendText: '* ' }
                 },
                 {
-                    beforeText: /^({2})* \*\/\s*$/,
+                    beforeText: /^( {2})* \*\/\s*$/,
                     action: { indentAction: vscode.IndentAction.None, removeText: 1 }
                 }
             ]


### PR DESCRIPTION
Error was

```
[VSCODE] ERROR in ./src/format/formatExtension.ts 146:29
[VSCODE] Module parse failed: Invalid regular expression: /^({2})* \*( ([^*]|\*(?!\/))*)?$/: Nothing to repeat (146:29)
[VSCODE] File was processed with these loaders:
[VSCODE]  * ../../node_modules/.for-vscode/ts-loader/index.js
[VSCODE] You may need an additional loader to handle the result of these loaders.
[VSCODE] |             },
[VSCODE] |             {
[VSCODE] >                 beforeText: /^({2})* \*( ([^*]|\*(?!\/))*)?$/,
[VSCODE] |                 action: { indentAction: vscode.IndentAction.None, appendText: '* ' }
[VSCODE] |             },
[VSCODE]  @ ./src/extension.ts 5:24-59
```